### PR TITLE
🐛 Fix line-break in capstone title

### DIFF
--- a/src/certificate.ts
+++ b/src/certificate.ts
@@ -360,12 +360,10 @@ async function renderThirdPage(
   textAlignmentY += doc.heightOfString('TITEL:') + 5;
 
   doc.font('src/assets/fonts/OpenSans/OpenSans-SemiBold.ttf');
-  doc.fillColor('#E74D0F');
-
   doc.fontSize(
     calculateFontSize(doc, `»${capstoneProject.title}«`, 10, 28, 200)
   );
-  doc.widthOfString(`»${capstoneProject.title}«`);
+  doc.fillColor('#E74D0F');
   doc.text(`»${capstoneProject.title}«`, 306, textAlignmentY);
 
   textAlignmentY += doc.heightOfString(`»${capstoneProject.title}«`, {

--- a/src/certificate.ts
+++ b/src/certificate.ts
@@ -359,12 +359,14 @@ async function renderThirdPage(
 
   textAlignmentY += doc.heightOfString('TITEL:') + 5;
 
-  doc.font('src/assets/fonts/OpenSans/OpenSans-SemiBold.ttf');
-  doc.fontSize(
-    calculateFontSize(doc, `»${capstoneProject.title}«`, 10, 28, 200)
-  );
-  doc.fillColor('#E74D0F');
-  doc.text(`»${capstoneProject.title}«`, 306, textAlignmentY);
+  text(doc, {
+    text: `»${capstoneProject.title}«`,
+    x: 306,
+    y: textAlignmentY,
+    fontSize: calculateFontSize(doc, `»${capstoneProject.title}«`, 10, 28, 200),
+    fillColor: '#E74D0F',
+    font: 'src/assets/fonts/OpenSans/OpenSans-SemiBold.ttf',
+  });
 
   textAlignmentY += doc.heightOfString(`»${capstoneProject.title}«`, {
     width: 200,

--- a/src/certificate.ts
+++ b/src/certificate.ts
@@ -363,7 +363,13 @@ async function renderThirdPage(
     text: `»${capstoneProject.title}«`,
     x: 306,
     y: textAlignmentY,
-    fontSize: calculateFontSize(doc, `»${capstoneProject.title}«`, 10, 28, 200),
+    fontSize: calculateFontSize({
+      doc,
+      text: `»${capstoneProject.title}«`,
+      minFontSize: 10,
+      maxFontSize: 28,
+      maxWidth: 200,
+    }),
     fillColor: '#E74D0F',
     font: 'src/assets/fonts/OpenSans/OpenSans-SemiBold.ttf',
   });

--- a/src/certificate.ts
+++ b/src/certificate.ts
@@ -3,6 +3,7 @@ import http from 'http';
 import fetch from 'node-fetch';
 import { Course, CourseTopics, Talent } from './api';
 import text from './components/text';
+import { calculateFontSize } from './utils';
 
 const A4SIZE: [number, number] = [595.28, 841.89];
 const PRIMARY_TEXT_COLOR = '#1A3251';
@@ -358,9 +359,13 @@ async function renderThirdPage(
 
   textAlignmentY += doc.heightOfString('TITEL:') + 5;
 
-  doc.fontSize(28);
-  doc.fillColor('#E74D0F');
   doc.font('src/assets/fonts/OpenSans/OpenSans-SemiBold.ttf');
+  doc.fillColor('#E74D0F');
+
+  doc.fontSize(
+    calculateFontSize(doc, `»${capstoneProject.title}«`, 10, 28, 200)
+  );
+  doc.widthOfString(`»${capstoneProject.title}«`);
   doc.text(`»${capstoneProject.title}«`, 306, textAlignmentY);
 
   textAlignmentY += doc.heightOfString(`»${capstoneProject.title}«`, {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,13 +2,20 @@ export function normalizeDiacritics(text: string): string {
   return text.normalize('NFD').replace(/\p{Diacritic}/gu, '');
 }
 
-export function calculateFontSize(
-  doc: PDFKit.PDFDocument,
-  text: string,
-  minFontSize: number,
-  maxFontSize: number,
-  maxWidth: number
-): number {
+type CalculateFontSizeProps = {
+  doc: PDFKit.PDFDocument;
+  text: string;
+  minFontSize: number;
+  maxFontSize: number;
+  maxWidth: number;
+};
+export function calculateFontSize({
+  doc,
+  text,
+  minFontSize,
+  maxFontSize,
+  maxWidth,
+}: CalculateFontSizeProps): number {
   let fontSize = maxFontSize;
   doc.fontSize(fontSize);
   while (doc.widthOfString(text) > maxWidth && fontSize > minFontSize) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,20 @@
 export function normalizeDiacritics(text: string): string {
   return text.normalize('NFD').replace(/\p{Diacritic}/gu, '');
 }
+
+export function calculateFontSize(
+  doc: PDFKit.PDFDocument,
+  text: string,
+  minFontSize: number,
+  maxFontSize: number,
+  maxWidth: number
+): number {
+  let fontSize = maxFontSize;
+  doc.fontSize(fontSize);
+  while (doc.widthOfString(text) > maxWidth && fontSize > minFontSize) {
+    fontSize -= 1;
+    doc.fontSize(fontSize);
+  }
+
+  return fontSize;
+}


### PR DESCRIPTION
There was an issue with long titles like `»tradeHammer«`:
![image](https://user-images.githubusercontent.com/10058950/124445728-169ef280-dd80-11eb-9be4-bcc6db96a454.png)

Now:
![image](https://user-images.githubusercontent.com/10058950/124445757-1e5e9700-dd80-11eb-9cc1-37614315e42e.png)

The title font-size is calculated based on the text and max-width. Thus, long titles have a smaller font-size.

Try it out:
https://nf-certifica-title-size-7oekkf.herokuapp.com/?id=13f27b3b-b69e-4a13-b2e3-2dc764243a33
